### PR TITLE
Dockerfile Modifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@
 # Author: Omar Santos, os@cisco.com
 
 
-FROM python:3.7.9-alpine as builder
+FROM python:3.7.10-alpine as builder
 
 WORKDIR /build
 COPY . .
 RUN python3 setup.py bdist_wheel
 
 
-FROM python:3.7.9-alpine
+FROM python:3.7.10-alpine
 
 COPY --from=builder /build/dist/*.whl /whl/
 RUN python3 -m pip --no-cache-dir install /whl/*.whl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,134 +1,21 @@
-# This is a Dockerfile to create a container running Python 3.7
-# and to install the openVulnQuery client (client for the Cisco openVuln API)
-# Author: Omar Santos os@cisco.com
+# This is a Dockerfile to create a container running Python 3.7 containing the
+# openVulnQuery module. The openVulnQuery module is a client for the Cisco
+# openVuln API.
+#
+# Author: Omar Santos, os@cisco.com
 
-FROM alpine:latest
 
-# ensure local python is preferred over distribution python
-ENV PATH /usr/local/bin:$PATH
+FROM python:3.7.9-alpine as builder
 
-# At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3.x;
-# that is a bug documented at: http://bugs.python.org/issue19846
+WORKDIR /build
+COPY . .
+RUN python3 setup.py bdist_wheel
 
-ENV LANG C.UTF-8
 
-# install ca-certificates so that HTTPS works consistently
-# other runtime dependencies for Python are installed later
-RUN apk add --no-cache ca-certificates
+FROM python:3.7.9-alpine
 
-ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.7.0
+COPY --from=builder /build/dist/*.whl /whl/
+RUN python3 -m pip --no-cache-dir install /whl/*.whl \
+    && rm -rf /whl
 
-RUN set -ex \
-  && apk add --no-cache --virtual .fetch-deps \
-    gnupg \
-    tar \
-    xz \
-  \
-  && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
-  && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
-  && gpg --batch --verify python.tar.xz.asc python.tar.xz \
-  && { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
-  && rm -rf "$GNUPGHOME" python.tar.xz.asc \
-  && mkdir -p /usr/src/python \
-  && tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
-  && rm python.tar.xz \
-  \
-  && apk add --no-cache --virtual .build-deps  \
-    bzip2-dev \
-    coreutils \
-    dpkg-dev dpkg \
-    expat-dev \
-    findutils \
-    gcc \
-    gdbm-dev \
-    libc-dev \
-    libffi-dev \
-    libnsl-dev \
-    libressl-dev \
-    libtirpc-dev \
-    linux-headers \
-    make \
-    ncurses-dev \
-    pax-utils \
-    readline-dev \
-    sqlite-dev \
-    tcl-dev \
-    tk \
-    tk-dev \
-    util-linux-dev \
-    xz-dev \
-    zlib-dev \
-    git \
-    gnupg \
-    openssh-client \
-    openssh-keygen \
-# add build deps before removing fetch deps in case there's overlap
-  && apk del .fetch-deps \
-  \
-  && cd /usr/src/python \
-  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-  && ./configure \
-    --build="$gnuArch" \
-    --enable-loadable-sqlite-extensions \
-    --enable-shared \
-    --with-system-expat \
-    --with-system-ffi \
-    --without-ensurepip \
-  && make -j "$(nproc)" \
-    EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-  && make install \
-  \
-  && find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
-    | tr ',' '\n' \
-    | sort -u \
-    | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-    | xargs -rt apk add --no-cache --virtual .python-rundeps \
-  && apk del .build-deps \
-  \
-  && find /usr/local -depth \
-    \( \
-      \( -type d -a \( -name test -o -name tests \) \) \
-      -o \
-      \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-    \) -exec rm -rf '{}' + \
-  && rm -rf /usr/src/python \
-  \
-  && python3 --version
-
-# make some useful symlinks that are expected to exist
-RUN cd /usr/local/bin \
-  && ln -s idle3 idle \
-  && ln -s pydoc3 pydoc \
-  && ln -s python3 python \
-  && ln -s python3-config python-config
-
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-
-ENV PYTHON_PIP_VERSION 18.1
-
-RUN set -ex; \
-  \
-  wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-  \
-  python get-pip.py \
-    --disable-pip-version-check \
-    --no-cache-dir \
-    "pip==$PYTHON_PIP_VERSION" \
-  ; \
-  pip --version; \
-  \
-  find /usr/local -depth \
-    \( \
-      \( -type d -a \( -name test -o -name tests \) \) \
-      -o \
-      \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-    \) -exec rm -rf '{}' +; \
-  rm -f get-pip.py
-
-# Finally installing the openVulnQuery client.
-RUN set -ex; \
-  python3 -m pip install openVulnQuery==1.30
-CMD ["python3"]
+CMD ["/usr/local/bin/python3"]


### PR DESCRIPTION
- Smaller image size:

```bash
$ podman images
REPOSITORY                           TAG           IMAGE ID      CREATED         SIZE
localhost/openvulnquery              modified      baea2e57ba5d  6 seconds ago   53.4 MB
localhost/openvulnquery              original      44db533e3899  21 minutes ago  96.7 MB
```

- Shorter build times:

```bash
$ time podman build -t openvulnquery:modified -f Dockerfile

real	0m20.183s
user	0m10.956s
sys	0m5.554s

$ time podman build -t openvulnquery:original -f Dockerfile

real	5m42.923s
user	6m57.954s
sys	1m27.090s
```

- Python 3.7.0 => Python 3.7.9 improvements (security and otherwise, [](https://docs.python.org/release/3.7.9/whatsnew/changelog.html#changelog))
- Easier to maintain Dockerfile that doesn't link the code to a particular published release. If it's desirable to get an image for a specific release that commit should be checked out and built (going forward).