### PR TITLE
Changes to support Cisco changes to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,14 @@ Obtain client ID and Secret:
 3. Select My Applications Tab
 4. Register a New Application by:
 
-  - Entering Application Name
-  - Under OAuth2.0 Credentials check Client Credentials
+  - Enter an application name
+  - Enter a description of your application.
+  - Application Type field is Service.
+  - Grant Type is Client Credentials.
   - Under Select APIs choose Cisco PSIRT openVuln API
   - Agree to the terms and service and click Register
 
-5. The following are the openVuln API rate limits:
-- 2 calls per second
-- 10 calls per minute
-
+5. The openVuln API rate limits are shown in the https://apiconsole.cisco.com/apps/mykeys
 6. Note the value of "Client ID" (a string like e.g. 'abc12abcd13abcdefabcde1a')
 7. Note the value of "Client Secret" (a string like e.g. '1a2abcDEfaBcDefAbcDeFA3b')
 8. Provide the credentials to the application at runtime via two preferred alternativev ways:

--- a/openVulnQuery/_library/authorization.py
+++ b/openVulnQuery/_library/authorization.py
@@ -19,5 +19,9 @@ def get_oauth_token(client_id, client_secret, request_token_url=None):
         params={'client_id': client_id, 'client_secret': client_secret},
         data={'grant_type': 'client_credentials'}
     )
+    # Added check to see if migrated to new API structure.
+    if r.status_code == 400:
+        print("Ensure you have updated your code as per https://raw.githubusercontent.com/api-at-cisco/Images/master/Whats_New_Doc.pdf")
+        exit()
     r.raise_for_status()
     return r.json()['access_token']

--- a/openVulnQuery/_library/config.py
+++ b/openVulnQuery/_library/config.py
@@ -9,5 +9,9 @@
 CLIENT_ID = ""
 CLIENT_SECRET = ""
 
-REQUEST_TOKEN_URL = "https://cloudsso.cisco.com/as/token.oauth2"
-API_URL = "https://api.cisco.com/security/advisories/v2"
+#The following two URLs have changed.  See https://raw.githubusercontent.com/api-at-cisco/Images/master/Whats_New_Doc.pdf
+#REQUEST_TOKEN_URL = "https://cloudsso.cisco.com/as/token.oauth2"
+#API_URL = "https://api.cisco.com/security/advisories/v2"
+
+REQUEST_TOKEN_URL = "https://id.cisco.com/oauth2/default/v1/token"
+API_URL = "https://apix.cisco.com/security/advisories/v2"


### PR DESCRIPTION
As per https://raw.githubusercontent.com/api-at-cisco/Images/master/Whats_New_Doc.pdf updated the token request URL and the base API URL:

REQUEST_TOKEN_URL = "https://id.cisco.com/oauth2/default/v1/token"
API_URL = "https://apix.cisco.com/security/advisories/v2"

Made a small change to indicate to user to point to documentation if using old credentials.

Updated Readme with the registration instructions.