### PR TITLE
Update python-package.yml

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9.16, 3.10.11, 3.11.3]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Upgrade to multiple Python versions in the GitHub Actions workflow. This commit adds a matrix strategy to the workflow that runs the tests and linting on four Python versions: 3.8, 3.9.16, 3.10.11, and 3.11.3. By testing the code on these versions, we can ensure compatibility with a broader range of Python environments and catch any issues early. The workflow also installs the necessary dependencies and uses `pytest` for testing. This upgrade will help us maintain a reliable and up-to-date codebase. As per the supported versions at: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

This should take care of the errors during your commits, @poxman 