### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022, Cisco Systems, Inc.
+Copyright (c) 2025, Cisco Systems, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation 
 files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, 


### PR DESCRIPTION
This pull request updates the copyright year in the `LICENSE` file to reflect the current year.

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L1-R1): Updated the copyright year from 2022 to 2025.