### PR TITLE
Update generator-generic-ossf-slsa3-publish.yml

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -60,7 +60,7 @@ jobs:
       actions: read   # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.4.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@main
     with:
       base64-subjects: "${{ needs.build.outputs.digests }}"
       upload-assets: true # Optional: Upload to a new release


### PR DESCRIPTION
This pull request updates the workflow configuration for publishing with SLSA3 compliance. The most significant change is the update to the version of the SLSA GitHub generator workflow being used.

Workflow updates:

* [`.github/workflows/generator-generic-ossf-slsa3-publish.yml`](diffhunk://#diff-98bd42f3b5e076be27172aad3387298cbca7505451064fb47b3a5c384bd0ca40L63-R63): Updated the `uses` field to reference the `main` branch of the SLSA GitHub generator workflow instead of the specific `v1.4.0` version. This allows the workflow to use the latest updates from the `main` branch.